### PR TITLE
Add [[nodiscard]] to result<T, E> to prevent silently ignored errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## master
 ### Added
 - Add Catch2 string serialization for `result<T, E>` and `error`.
+- Add [[nodiscard]] attribute to `result<T, E>` to prevent silently ignored errors.

--- a/include/estd/result/result.hpp
+++ b/include/estd/result/result.hpp
@@ -51,7 +51,7 @@ T && make_default_exception (T && in) { return in; }
 inline std::system_error make_default_exception (std::error_code error) { return error; }
 
 template<typename T, typename E>
-class result {
+class [[nodiscard]] result {
 public:
 	using Type  = T;
 	using Error = E;
@@ -212,7 +212,7 @@ private:
 };
 
 template<typename E>
-class result<void, E> {
+class [[nodiscard]] result<void, E> {
 public:
 	using Type  = void;
 	using Error = E;


### PR DESCRIPTION
No more silently ignored `Result`s!