### PR TITLE
Add `error::last_os_error()` to wrap `errno`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## master
+### Added
+- Add `error::last_os_error()` overloads to create an error from `errno`.
 
 ## 0.4.0 - 2020-09-01
 ### Added

--- a/include/estd/result/error.hpp
+++ b/include/estd/result/error.hpp
@@ -2,6 +2,7 @@
 #include "./unspecified_category.hpp"
 
 #include <initializer_list>
+#include <cerrno>
 #include <string>
 #include <system_error>
 #include <type_traits>
@@ -73,11 +74,43 @@ struct error {
 	/// Create an unspecified error with a description.
 	explicit error(std::string description) : error{unspecified_errc::unspecified, std::move(description)} {};
 
-	///// Create an unspecified error with a description stack.
+	/// Create an unspecified error with a description stack.
 	explicit error(std::vector<std::string> description) : error{unspecified_errc::unspecified, std::move(description)} {}
 
 	/// Create an unspecified error with a description stack.
 	explicit error(std::initializer_list<std::string> description) : error(std::vector<std::string>{std::move(description)}) {};
+
+	/// Create an error using the last OS error.
+	/**
+	 * This function uses `errno` to create the error code.
+	 */
+	static error last_os_error() {
+		return std::error_code{errno, std::generic_category()};
+	}
+
+	/// Create an error using the last OS error and a description.
+	/**
+	 * This function uses `errno` to create the error code.
+	 */
+	static error last_os_error(std::string description) {
+		return {std::error_code{errno, std::generic_category()}, std::move(description)};
+	}
+
+	/// Create an error using the last OS error and a description stack.
+	/**
+	 * This function uses `errno` to create the error code.
+	 */
+	static error last_os_error(std::vector<std::string> description) {
+		return {std::error_code{errno, std::generic_category()}, std::move(description)};
+	}
+
+	/// Create an error using the last OS error and a description stack.
+	/**
+	 * This function uses `errno` to create the error code.
+	 */
+	static error last_os_error(std::initializer_list<std::string> description) {
+		return {std::error_code{errno, std::generic_category()}, std::move(description)};
+	}
 
 	/// Check if this error represents an error and not sucess.
 	explicit operator bool() const noexcept {

--- a/test/result/error.cpp
+++ b/test/result/error.cpp
@@ -32,6 +32,8 @@
 
 #include <catch2/catch.hpp>
 
+#include <cerrno>
+
 namespace estd {
 
 class test_category_ : public std::error_category {
@@ -116,6 +118,11 @@ TEST_CASE("error.format() formats correctly", "[result]") {
 			CHECK(error(unspecified_errc::unspecified).format() == "unspecified error -1");
 		}
 	}
+}
+
+TEST_CASE("error.last_os_error() wraps errno correctly", "[result]") {
+	errno = ENOENT;
+	CHECK(error::last_os_error() == std::errc::no_such_file_or_directory);
 }
 
 }


### PR DESCRIPTION
This PR adds static constructors for `error` that wrap `errno`.

Can be quite useful when you want to return an error code for failed file operations or similar. Although technically the C++ standard library doesn't guarantee that `errno` isn't clobbered by `fstream` and friends. In practise it works.