### PR TITLE
Ensure input to `std::from_chars` is char pointers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## master
+### Fixed
+- Fix undefined behaviour in `numerical_to_string`.
+- Fix portability of `string_to_numerical`.
 
 ## 0.6.1 - 2021-06-09
 ### Fixed
-- Fix `string_to_numerical` undefined behaviour.
+- Fix undefined behaviour in `string_to_numerical`.
 
 ## 0.6.0 - 2020-10-19
 ### Added

--- a/include/estd/convert/numerical.hpp
+++ b/include/estd/convert/numerical.hpp
@@ -43,7 +43,7 @@ namespace impl {
 	template<typename T>
 	result<T, error> string_to_numerical(std::string_view input) {
 		T value;
-		auto [ptr, error] = std::from_chars(input.begin(), input.end(), value);
+		auto [ptr, error] = std::from_chars(input.data(), input.data() + input.size(), value);
 		if (error != std::errc{}) return estd::error{error};
 		if (ptr != input.end())   return estd::error{std::errc::invalid_argument};
 		return {estd::in_place_valid, value};
@@ -55,14 +55,14 @@ namespace impl {
 		std::string result;
 		result.resize(16);
 		while (true) {
-			auto [ptr, error] = std::to_chars(&result[0], &result[result.size()], input);
+			auto [ptr, error] = std::to_chars(result.data(), result.data() + result.size(), input);
 			if (error == std::errc::value_too_large && result.size() < 1024) {
 				result.resize(result.size() * 2);
 			} else if (error != std::errc{}) {
 				return estd::error{error};
 			} else {
 				// Resize down to the used space.
-				result.resize(ptr - &result[0]);
+				result.resize(ptr - result.data());
 				return {estd::in_place_valid, std::move(result)};
 			}
 		}


### PR DESCRIPTION
[`std::from_chars`] only accepts `char const *` as input, not iterators. Iterators of contiguous containers tend to be implicitly convertible to pointers, but this is not guaranteed by the standard. Since C++20 there is [`std::to_address`] for this, but that seems a lot overkill here.

Instead, we can use `string[_view].data()` to get a pointer to the start of the string, and use the size to also get a pointer to the end.

The same UB was also in `string_to_numerical`, so I fixed that one too.

[`std::from_chars`]: https://en.cppreference.com/w/cpp/utility/from_chars
[`std::to_address`]: https://en.cppreference.com/w/cpp/memory/to_address