### PR TITLE
Fix zip() with tuples for GCC 11.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,3 @@
 # Unreleased
 - [add][minor] Enable conversions between strings and floating point types.
+- [fix][patch] Fix `estd::zip()` for tuples with GCC 11.

--- a/include/estd/tuple/zip.hpp
+++ b/include/estd/tuple/zip.hpp
@@ -47,8 +47,8 @@ namespace detail {
 	}
 
 	template<typename... Tuples, std::size_t... I>
-	std::tuple<zip_tuple_at_index_t<I, Tuples...>...> tuple_zip(Tuples && ...tuples, std::index_sequence<I...>) {
-		return {zip_tuple_at_index<I>(std::forward<Tuples>(tuples)...)...};
+	auto tuple_zip(Tuples && ...tuples, std::index_sequence<I...>) {
+		return std::make_tuple(zip_tuple_at_index<I>(std::forward<Tuples>(tuples)...)...);
 	}
 
 }


### PR DESCRIPTION
It actually looks like a compiler bug if you ask me, but we can work around it.