### PR TITLE
Exclude clang from GCC check.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
 # Version 0.6.3 - 2021-10-11
 - [add][minor] Enable conversions between strings and floating point types.
 - [fix][patch] Fix `estd::zip()` for tuples with GCC 11.
+- [fix][minor] Ignore non-gcc compilers in numerical conversion check.

--- a/include/estd/convert/numerical.hpp
+++ b/include/estd/convert/numerical.hpp
@@ -114,7 +114,7 @@ ESTD_DEFINE_NUMERICAL_CONVERSIONS(unsigned long);
 ESTD_DEFINE_NUMERICAL_CONVERSIONS(long long);
 ESTD_DEFINE_NUMERICAL_CONVERSIONS(unsigned long long);
 
-#if defined(__GNUC__) && __GNUC__ < 11
+#if defined(__GNUC__) && __GNUC__ < 11 && !defined(__llvm__) && !defined(__INTEL_COMPILER)
 #error "GCC version is too old for floating point/string conversions. You need at-least GCC 11."
 #else
 ESTD_DEFINE_NUMERICAL_CONVERSIONS(float);


### PR DESCRIPTION
This check fails on clang because it defines `__GNUC__`, but it's value is `4`.